### PR TITLE
Handle unknown method blocks in flyouts

### DIFF
--- a/core/flyout.js
+++ b/core/flyout.js
@@ -778,15 +778,19 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       var tagName = xml.tagName.toUpperCase();
       var default_gap = this.horizontalLayout_ ? this.GAP_X : this.GAP_Y;
       if (tagName == 'BLOCK') {
-        var curBlock = Blockly.Xml.domToBlock(xml, this.workspace_);
-        if (curBlock.disabled) {
-          // Record blocks that were initially disabled.
-          // Do not enable these blocks as a result of capacity filtering.
-          this.permanentlyDisabled_.push(curBlock);
+        try {
+          var curBlock = Blockly.Xml.domToBlock(xml, this.workspace_);
+          if (curBlock.disabled) {
+            // Record blocks that were initially disabled.
+            // Do not enable these blocks as a result of capacity filtering.
+            this.permanentlyDisabled_.push(curBlock);
+          }
+          contents.push({type: 'block', block: curBlock});
+          var gap = parseInt(xml.getAttribute('gap'), 10);
+          gaps.push(isNaN(gap) ? default_gap : gap);
+        } catch(e) {
+          console.error(e);
         }
-        contents.push({type: 'block', block: curBlock});
-        var gap = parseInt(xml.getAttribute('gap'), 10);
-        gaps.push(isNaN(gap) ? default_gap : gap);
       } else if (xml.tagName.toUpperCase() == 'SEP') {
         // Change the gap between two blocks.
         // <sep gap="36"></sep>


### PR DESCRIPTION
This is the patch to fix mit-cml/appinventor-sources#1200 via PR mit-cml/appinventor-sources#1475. Do not merge this on GitHub since it will mess up the SHA1 and require updating the PR. Instead, pull the branch to your local and then push to `mitmaster` to "merge" it if it looks good.