### PR TITLE
Made blocks return to original position if trash is canceled

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -690,6 +690,7 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
         new Blockly.Events.Ui(this, 'click', undefined, undefined));
   }
   Blockly.terminateDrag_();
+  var oldXY = this.dragStartXY_;
 
   var deleteArea = this.workspace.isDeleteArea(e);
 
@@ -719,6 +720,12 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
       }
       if (confirmedDelete) {
 	Blockly.selected.dispose(false, true);
+      }
+      else{
+        //Move block back to original position if trash is canceled
+        var group = Blockly.selected.getSvgRoot();
+        group.translate_ = 'translate(' + oldXY.x + ',' + oldXY.y + ')';
+        group.setAttribute('transform', group.translate_ + group.skew_);
       }
     });
   }

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -720,8 +720,7 @@ Blockly.BlockSvg.prototype.onMouseUp_ = function(e) {
       }
       if (confirmedDelete) {
 	Blockly.selected.dispose(false, true);
-      }
-      else{
+      } else {
         //Move block back to original position if trash is canceled
         var group = Blockly.selected.getSvgRoot();
         group.translate_ = 'translate(' + oldXY.x + ',' + oldXY.y + ')';


### PR DESCRIPTION
Thanks for submitting code to Blockly!  Please fill out the following as part of your pull request so we can review your code more easily.

## The basics

- [ ] I branched from develop
- [ ] My pull request is against develop
- [x ] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves

_What Github issue does this resolve (please include link)?_
#1210 from MIT AppInventor, in which blocks do not move back to their original position when the trash action is canceled.
https://github.com/mit-cml/appinventor-sources/issues/1210

### Proposed Changes
_Describe what this Pull Request does.  Include screenshots if applicable._
If a group of 3 or more blocks gets dragged to the trashcan, the dialog box for confirmation will pop up. If the user clicks "cancel", the block will jump back to the position it was originally dragged from.

### Reason for Changes
_Explain why these changes should be made.  Include screenshots if applicable._
The issue was brought up in AppInventor, and this will make the user experience better, as they will not have to reposition the piece

### Test Coverage
_Please show how you have added tests to cover your changes, or tell us how you tested it and on which platforms._
I tested the change on MIT AppInventor locally, and tested it by dragging blocks to the trashcan and checking if it moves back to its original position when the trashing is canceled. I also checked to make sure everything else still works.

Tested on:
- [ ] Desktop:
  - [ x] Chrome
  - [ x] Firefox
  - [ ] Safari
  - [ ] Opera
  - [ ] IE 10+
  - [ ] IE 11
  - [ ] EDGE

- [ ] Smartphone/Tablet/Chromebook (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
  
### Additional Information

_Anything else we should know?_
