### PR TITLE
Change flyout block creation. Fix disabled.

### DIFF
--- a/core/flyout.js
+++ b/core/flyout.js
@@ -768,7 +768,6 @@ Blockly.Flyout.prototype.show = function(xmlList) {
   }
 
   this.setVisible(true);
-  this.workspace_.rendered = false;
   // Create the blocks to be shown in this flyout.
   var contents = [];
   var gaps = [];
@@ -815,12 +814,6 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       }
     }
   }
-  this.workspace_.rendered = true;
-  var blocks = goog.object.getValues(this.workspace_.blockDB_);
-  for (var i = 0; i < blocks.length; i++) {
-    blocks[i].initSvg();
-  }
-  this.workspace_.render();
 
   this.layout_(contents, gaps);
 
@@ -1209,6 +1202,19 @@ Blockly.Flyout.prototype.isDragTowardWorkspace_ = function(dx, dy) {
   return false;
 };
 
+// These changes mimic how core works on the latest version, and can be safely
+// removed during an upgrade.
+/**
+ * Returns if the flyout allows a new instance of the given block to be created.
+ * Used for deciding if a block can be "dragged out of" the flyout.
+ * By default all non-disabled blocks are creatable.
+ * @param {!Blockly.BlockSvg} block The block to copy from the flyout.
+ * @return {boolean} True if the flyout allows the block to be instantiated.
+ */
+Blockly.Flyout.prototype.isBlockCreatable_ = function(block) {
+  return !block.disabled;
+}
+
 /**
  * Create a copy of this block on the workspace.
  * @param {!Blockly.Block} originBlock The flyout block to copy.
@@ -1222,8 +1228,7 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
       // Right-click.  Don't create a block, let the context menu show.
       return;
     }
-    if (originBlock.disabled) {
-      // Beyond capacity.
+    if (!flyout.isBlockCreatable_(originBlock)) {
       return;
     }
     Blockly.Events.disable();


### PR DESCRIPTION
 ### Description

This is one half of fixing https://github.com/mit-cml/appinventor-sources/issues/2147.

1) **Adds isBlockCreatable_ to the flyout.** I think it is best to add this here instead of in the app inventor repo, because when you upgraded you would have to revert/deal with those changes. If I put them here (since we are just replicating the behavior of future version of blockly) you can just ignore this commit when you upgrade.

    In less words: Adding this here means you shouldn't have to do anything when you upgrade.

2) **Reverts the change found [here](https://github.com/mit-cml/blockly/commit/fe8ec09de6afbce6273bb04c0ac27be74c86e253).** I discovered that this was why the disabled blocks appeared to be black. Because the workspace wasn't rendered domToBlock was never calling updateDisabled, so the blocks would get stuck without a fill.

    I did some testing, and I don't /think/ that change had a huge impact on performance, but I might not have been testing the right things.

   Totally willing to revert this reversion! I just figured: better to remove code than to add it.

### Testing

To test the performance impact I did the following:
1) Add a date picker to the app (because it has a large-ish flyout).
2) Set up Instrumentation.
3) Opened the flyout.
4) Logged the instrumentation data.

From my reading of the instrumentation data leaving the workspace rendered actually makes less calls, but who knows if I'm reading it right or if there are other things I should be looking at.

[ThisBranch.log](https://github.com/mit-cml/blockly/files/4453161/ThisBranch.log)
```
ode-0.js:272630   topBlockCount=0
ode-0.js:272630   blockCount=0
...
ode-0.js:272630   renderDownCalls=80
ode-0.js:272630   renderDownTime=0
ode-0.js:272630   renderHereCalls=80
ode-0.js:272630   renderHereTime=88
...
ode-0.js:272630   getTopBlocksCalls=92
ode-0.js:272630   getTopBlocksTime=0
ode-0.js:272630   getAllBlocksCalls=2
```
[Old.log](https://github.com/mit-cml/blockly/files/4453162/Old.log)
```
ode-0.js:272632   topBlockCount=40
ode-0.js:272632   blockCount=40
...
ode-0.js:272632   renderDownCalls=80
ode-0.js:272632   renderDownTime=58
ode-0.js:272632   renderHereCalls=80
ode-0.js:272632   renderHereTime=59
...
ode-0.js:272632   getTopBlocksCalls=94
ode-0.js:272632   getTopBlocksTime=0
ode-0.js:272632   getAllBlocksCalls=3
```

### Additional Info

I think I set up this PR correctly? But I'm not sure. If I need to change anything definitely tell me.

If/when this gets in I'll put up the other half into the app-inventor repo.