### PR TITLE
Add max flyout width

### DIFF
--- a/core/flyout.js
+++ b/core/flyout.js
@@ -131,6 +131,13 @@ Blockly.Flyout = function(workspaceOptions) {
  */
 Blockly.Flyout.prototype.VERTICAL_SEPARATION_FACTOR = 2;
 
+/**
+ * The maximum width in pixels a vertical flyout can be.
+ * @type {number}
+ * @const
+ */
+Blockly.Flyout.prototype.MAX_WIDTH = 300;
+
 /*
  * Wrapper function called when a resize occurs.
  * @type {Array.<!Array>}
@@ -308,7 +315,17 @@ Blockly.Flyout.prototype.createDom = function(tagName) {
       {'class': 'blocklyFlyout', 'style': 'display: none'}, null);
   this.svgBackground_ = Blockly.utils.createSvgElement('path',
       {'class': 'blocklyFlyoutBackground'}, this.svgGroup_);
-  this.svgGroup_.appendChild(this.workspace_.createDom());
+
+  // Must include random because there will be multiple of these on the page.
+  var id = 'blocklyFlyoutClipPath' + String(Math.random()).substring(2);
+  var clipPath = Blockly.utils.createSvgElement('clipPath',
+      {'id': id}, this.svgGroup_);
+  this.clip_ = Blockly.utils.createSvgElement('rect', {'x': 0, 'y': 0}, clipPath);
+
+  var workspaceDom = this.workspace_.createDom();
+  workspaceDom.setAttribute('clip-path', 'url(#' + id + ')');
+  this.svgGroup_.appendChild(workspaceDom);
+
   Array.prototype.push.apply(this.eventWrappers_,
       Blockly.bindEvent_(this.svgGroup_, 'wheel', this, this.wheel_));
   // Dragging the flyout up and down.
@@ -516,6 +533,8 @@ Blockly.Flyout.prototype.position = function() {
     this.height_ = targetWorkspaceMetrics.viewHeight;
   }
 
+  this.clip_.setAttribute('width', this.width_ + 'px');
+  this.clip_.setAttribute('height', this.height_ + 'px');
   this.svgGroup_.setAttribute("width", this.width_);
   this.svgGroup_.setAttribute("height", this.height_);
   var transform = 'translate(' + x + 'px,' + y + 'px)';
@@ -1485,6 +1504,7 @@ Blockly.Flyout.prototype.reflowVertical = function(blocks) {
   flyoutWidth += this.MARGIN * 1.5 + Blockly.BlockSvg.TAB_WIDTH;
   flyoutWidth *= this.workspace_.scale;
   flyoutWidth += Blockly.Scrollbar.scrollbarThickness;
+  flyoutWidth = Math.min(flyoutWidth, this.MAX_WIDTH);
   if (this.width_ != flyoutWidth) {
     for (var i = 0, block; block = blocks[i]; i++) {
       var blockHW = block.getHeightWidth();


### PR DESCRIPTION
### Description

Closes https://github.com/mit-cml/appinventor-sources/issues/2156

Adds a maximum width to the flyout (300px). This does not add horizontal scrolling, because after seeing the simple width-limiting behavior I don't believe it is necessary. In all of the components/drawers I have tested 300px is large enough that you can see what the block will do before selecting it.

I think that adding horizontal scrolling will just make this code more difficult to maintain in the future. If you want to use two scrollbars you have to interact with a Blockly.ScrollbarPair rather than a Blockly.Scrollbar, and they have different interfaces. I would recommend staying away from anything related to coordinates, if at all possible.

But I'm still open to the possibility. Tell me whatcha think =)

![Procedures](https://user-images.githubusercontent.com/25440652/89572289-c9b44400-d7dd-11ea-84c8-eb24e21c2612.png)
![Dictionaries](https://user-images.githubusercontent.com/25440652/89572294-cae57100-d7dd-11ea-8f69-f9003c13c2a4.png)
![Screen](https://user-images.githubusercontent.com/25440652/89572298-cc169e00-d7dd-11ea-80b9-fc9ba7c17bb0.png)
![Backpack](https://user-images.githubusercontent.com/25440652/89572302-cd47cb00-d7dd-11ea-8158-ff6ea1b5cd23.png)

